### PR TITLE
Use the rendered compact JSON format for internal logs

### DIFF
--- a/src/Seq.Forwarder/Cli/Commands/RunCommand.cs
+++ b/src/Seq.Forwarder/Cli/Commands/RunCommand.cs
@@ -89,7 +89,7 @@ namespace Seq.Forwarder.Cli.Commands
                 .Enrich.FromLogContext()
                 .MinimumLevel.Is(internalLoggingLevel)
                 .WriteTo.RollingFile(
-                    new CompactJsonFormatter(),
+                    new RenderedCompactJsonFormatter(),
                     GetRollingLogFilePathFormat(internalLogPath),
                     fileSizeLimitBytes: 1024*1024);
             


### PR DESCRIPTION
It's more readable but still reasonably toolable, e.g.:

```
{"@t":"2017-04-02T11:02:12.8053758Z","@m":"Seq Forwarder listening on \"http://localhost:15341\"","@i":"bc80c4c1","ListenUri":"http://localhost:15341"}
{"@t":"2017-04-02T11:02:12.8711151Z","@m":"Log buffer open on \"C:\\ProgramData\\Seq\\Forwarder\\Buffer\"; 0 entries, next key will be 1","@i":"505684b8","BufferPath":"C:\\ProgramData\\Seq\\Forwarder\\Buffer","Entries":0,"NextId":1}
{"@t":"2017-04-02T11:02:12.9054351Z","@m":"Log shipper started, events will be dispatched to \"http://localhost:5341\"","@i":"8bd6415c","ServerUrl":"http://localhost:5341"}
{"@t":"2017-04-02T11:02:19.7082147Z","@m":"Seq Forwarder stopped cleanly","@i":"2e9e2221"}
```
