### PR TITLE
Ensure the truncate and dump commands always dispose LogBuffer

### DIFF
--- a/src/Seq.Forwarder/Cli/Commands/DumpCommand.cs
+++ b/src/Seq.Forwarder/Cli/Commands/DumpCommand.cs
@@ -37,12 +37,14 @@ namespace Seq.Forwarder.Cli.Commands
             try
             {
                 var config = SeqForwarderConfig.Read(_storagePath.ConfigFilePath);
-                var buffer = new LogBuffer(_storagePath.BufferPath, config.Storage.BufferSizeBytes);
-                buffer.Enumerate((k, v) =>
+                using (var buffer = new LogBuffer(_storagePath.BufferPath, config.Storage.BufferSizeBytes))
                 {
-                    var s = Encoding.UTF8.GetString(v);
-                    Console.WriteLine(s);
-                });
+                    buffer.Enumerate((k, v) =>
+                    {
+                        var s = Encoding.UTF8.GetString(v);
+                        Console.WriteLine(s);
+                    });
+                }
                 return 0;
             }
             catch (Exception ex)

--- a/src/Seq.Forwarder/Cli/Commands/TruncateCommand.cs
+++ b/src/Seq.Forwarder/Cli/Commands/TruncateCommand.cs
@@ -36,8 +36,10 @@ namespace Seq.Forwarder.Cli.Commands
             try
             {
                 var config = SeqForwarderConfig.Read(_storagePath.ConfigFilePath);
-                var buffer = new LogBuffer(_storagePath.BufferPath, config.Storage.BufferSizeBytes);
-                buffer.Truncate();
+                using (var buffer = new LogBuffer(_storagePath.BufferPath, config.Storage.BufferSizeBytes))
+                {
+                    buffer.Truncate();
+                }
                 return 0;
             }
             catch (Exception ex)


### PR DESCRIPTION
Avoids a warning if the implementation of these commands fails for any reason.