### PR TITLE
Revert the config setting name back to output.apiKey

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -22,7 +22,7 @@ function Update-WixVersion($version)
 function Execute-MSBuild($version, $suffix)
 {
 	if ($suffix) {
-		& msbuild ./seq-forwarder.sln /t:Rebuild /p:Configuration=Release /p:Platform=x64 /p:VersionPrefix=$version /p:VersionSuffix=$suffix
+		& msbuild ./seq-forwarder.sln /t:Rebuild /p:Configuration=Release /p:Platform=x64 /p:VersionPrefix=$version-* /p:VersionSuffix=$suffix
 	} else {
 		& msbuild ./seq-forwarder.sln /t:Rebuild /p:Configuration=Release /p:Platform=x64 /p:VersionPrefix=$version
 	}

--- a/Build.ps1
+++ b/Build.ps1
@@ -8,18 +8,6 @@ function Restore-Packages
 	& nuget restore
 }
 
-function Update-AssemblyInfo($version)
-{  
-    $versionPattern = "[0-9]+(\.([0-9]+|\*)){3}"
-
-    foreach ($file in ls ./src/*/Properties/AssemblyInfo.cs)  
-    {     
-        (cat $file) | foreach {  
-                % {$_ -replace $versionPattern, "$version.0" }             
-            } | sc -Encoding "UTF8" $file                                 
-    }  
-}
-
 function Update-WixVersion($version)
 {
     $defPattern = "define Version = ""0\.0\.0"""
@@ -31,9 +19,13 @@ function Update-WixVersion($version)
         } | sc -Encoding "UTF8" $product
 }
 
-function Execute-MSBuild
+function Execute-MSBuild($version, $suffix)
 {
-	& msbuild ./seq-forwarder.sln /t:Rebuild /p:Configuration=Release /p:Platform=x64
+	if ($suffix) {
+		& msbuild ./seq-forwarder.sln /t:Rebuild /p:Configuration=Release /p:Platform=x64 /p:VersionPrefix=$version /p:VersionSuffix=$suffix
+	} else {
+		& msbuild ./seq-forwarder.sln /t:Rebuild /p:Configuration=Release /p:Platform=x64 /p:VersionPrefix=$version
+	}
 	if($LASTEXITCODE -ne 0) { exit 1 }
 }
 
@@ -47,23 +39,29 @@ function Execute-Tests
     popd
 }
 
-function Publish-Artifacts($version)
+function Publish-Artifacts($version, $suffix)
 {
+	$dashsuffix = "";
+	if ($suffix) {
+		$dashsuffix = "-$suffix";
+	}
 	mkdir ./artifacts
-	mv ./setup/SeqForwarder/bin/Release/SeqForwarder.msi ./artifacts/SeqForwarder-$version-pre.msi
+	mv ./setup/SeqForwarder/bin/Release/SeqForwarder.msi ./artifacts/SeqForwarder-$version$dashsuffix.msi
 	if($LASTEXITCODE -ne 0) { exit 1 }
 }
 
 Push-Location $PSScriptRoot
 
-$version = @{ $true = $env:APPVEYOR_BUILD_VERSION; $false = "0.0.0" }[$env:APPVEYOR_BUILD_VERSION -ne $NULL];
+$version = @{ $true = $env:APPVEYOR_BUILD_VERSION; $false = "99.99.99" }[$env:APPVEYOR_BUILD_VERSION -ne $NULL];
+$branch = @{ $true = $env:APPVEYOR_REPO_BRANCH; $false = $(git symbolic-ref --short -q HEAD) }[$env:APPVEYOR_REPO_BRANCH -ne $NULL];
+$revision = @{ $true = "{0:00000}" -f [convert]::ToInt32("0" + $env:APPVEYOR_BUILD_NUMBER, 10); $false = "local" }[$env:APPVEYOR_BUILD_NUMBER -ne $NULL];
+$suffix = @{ $true = ""; $false = "$($branch.Substring(0, [math]::Min(10,$branch.Length)))-$revision"}[$branch -eq "master" -and $revision -ne "local"]
 
 Clean-Output
 Restore-Packages
-Update-AssemblyInfo($version)
 Update-WixVersion($version)
-Execute-MSBuild
+Execute-MSBuild($version, $suffix)
 Execute-Tests
-Publish-Artifacts($version)
+Publish-Artifacts($version, $suffix)
 
 Pop-Location

--- a/Build.ps1
+++ b/Build.ps1
@@ -21,8 +21,10 @@ function Update-WixVersion($version)
 
 function Execute-MSBuild($version, $suffix)
 {
+	Write-Output "Building $version (suffix=$suffix)"
+
 	if ($suffix) {
-		& msbuild ./seq-forwarder.sln /t:Rebuild /p:Configuration=Release /p:Platform=x64 /p:Version=$version-* /p:VersionSuffix=$suffix
+		& msbuild ./seq-forwarder.sln /t:Rebuild /p:Configuration=Release /p:Platform=x64 /p:VersionPrefix=$version /p:VersionSuffix=$suffix
 	} else {
 		& msbuild ./seq-forwarder.sln /t:Rebuild /p:Configuration=Release /p:Platform=x64 /p:VersionPrefix=$version
 	}
@@ -59,9 +61,9 @@ $suffix = @{ $true = ""; $false = "$($branch.Substring(0, [math]::Min(10,$branch
 
 Clean-Output
 Restore-Packages
-Update-WixVersion($version)
-Execute-MSBuild($version, $suffix)
+Update-WixVersion $version
+Execute-MSBuild $version $suffix
 Execute-Tests
-Publish-Artifacts($version, $suffix)
+Publish-Artifacts $version $suffix
 
 Pop-Location

--- a/Build.ps1
+++ b/Build.ps1
@@ -22,7 +22,7 @@ function Update-WixVersion($version)
 function Execute-MSBuild($version, $suffix)
 {
 	if ($suffix) {
-		& msbuild ./seq-forwarder.sln /t:Rebuild /p:Configuration=Release /p:Platform=x64 /p:VersionPrefix=$version-* /p:VersionSuffix=$suffix
+		& msbuild ./seq-forwarder.sln /t:Rebuild /p:Configuration=Release /p:Platform=x64 /p:Version=$version-* /p:VersionSuffix=$suffix
 	} else {
 		& msbuild ./seq-forwarder.sln /t:Rebuild /p:Configuration=Release /p:Platform=x64 /p:VersionPrefix=$version
 	}

--- a/src/Seq.Forwarder/Cli/Commands/ImportCommand.cs
+++ b/src/Seq.Forwarder/Cli/Commands/ImportCommand.cs
@@ -78,7 +78,7 @@ namespace Seq.Forwarder.Cli.Commands
                     if (!string.IsNullOrEmpty(config.Output.ServerUrl))
                     {
                         serverUrl = config.Output.ServerUrl;
-                        apiKey = _serverInformation.IsApiKeySpecified ? _serverInformation.ApiKey : config.Output.DefaultApiKey;
+                        apiKey = _serverInformation.IsApiKeySpecified ? _serverInformation.ApiKey : config.Output.ApiKey;
                     }
                 }
 

--- a/src/Seq.Forwarder/Cli/Commands/VersionCommand.cs
+++ b/src/Seq.Forwarder/Cli/Commands/VersionCommand.cs
@@ -22,7 +22,7 @@ namespace Seq.Forwarder.Cli.Commands
     {
         protected override int Run(TextWriter cout)
         {
-            var version = Assembly.GetEntryAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+            var version = typeof(VersionCommand).GetTypeInfo().GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
             cout.WriteLine(version);
             return 0;
         }

--- a/src/Seq.Forwarder/Config/SeqForwarderOutputConfig.cs
+++ b/src/Seq.Forwarder/Config/SeqForwarderOutputConfig.cs
@@ -29,7 +29,7 @@ namespace Seq.Forwarder.Config
         public string EncodedApiKey { get; set; }
 
         [JsonIgnore]
-        public string DefaultApiKey
+        public string ApiKey
         {
             get
             {

--- a/src/Seq.Forwarder/Multiplexing/ActiveLogBufferMap.cs
+++ b/src/Seq.Forwarder/Multiplexing/ActiveLogBufferMap.cs
@@ -71,7 +71,7 @@ namespace Seq.Forwarder.Multiplexing
                     }
                     else
                     {
-                        _noApiKeyLogBuffer = new ActiveLogBuffer(buffer, _shipperFactory.Create(buffer, _outputConfig.DefaultApiKey));
+                        _noApiKeyLogBuffer = new ActiveLogBuffer(buffer, _shipperFactory.Create(buffer, _outputConfig.ApiKey));
                     }
                 }
 
@@ -135,7 +135,7 @@ namespace Seq.Forwarder.Multiplexing
                     {
                         _log.Information("Creating a new default log buffer in {Path}", _bufferPath);
                         var buffer = new LogBuffer(_bufferPath, _bufferSizeBytes);
-                        _noApiKeyLogBuffer = new ActiveLogBuffer(buffer, _shipperFactory.Create(buffer, _outputConfig.DefaultApiKey));
+                        _noApiKeyLogBuffer = new ActiveLogBuffer(buffer, _shipperFactory.Create(buffer, _outputConfig.ApiKey));
                         _noApiKeyLogBuffer.Shipper.Start();
                     }
                     return _noApiKeyLogBuffer.Buffer;

--- a/src/Seq.Forwarder/Seq.Forwarder.csproj
+++ b/src/Seq.Forwarder/Seq.Forwarder.csproj
@@ -16,9 +16,11 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <AssemblyTitle>Seq.Forwarder</AssemblyTitle>
     <Description>Seq HTTP Log Forwarder</Description>
-    <Copyright>Copyright © Datalust Pty Ltd and contributors 2017</Copyright>
+    <Copyright>Copyright © Datalust Pty Ltd and Contributors 2017</Copyright>
     <AssemblyName>seq-forwarder</AssemblyName>
-    <Platforms>AnyCPU;x64</Platforms>
+    <Platforms>x64</Platforms>
+    <GenerateAssemblyVersionAttribute>True</GenerateAssemblyVersionAttribute>
+    <GenerateAssemblyInformationalVersionAttribute>True</GenerateAssemblyInformationalVersionAttribute>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Simplest way to stay compatible with existing scripts. Tweaks build versioning (builds from master will no longer be designated pre-release).