### PR TITLE
Fix http client usage timeouts and port open length

### DIFF
--- a/src/Seq.Forwarder/Config/SeqForwarderOutputConfig.cs
+++ b/src/Seq.Forwarder/Config/SeqForwarderOutputConfig.cs
@@ -22,9 +22,10 @@ namespace Seq.Forwarder.Config
         const string ProtectedDataPrefix = "pd.";
 
         public string ServerUrl { get; set; } = "http://localhost:5341";
+        public int SocketLifetime { get; set; } = 60000 * 3; //this is what we use for lifetime, 1-5 minutes is pretty much the range so if there is a sweet spot for how the log shipper runs, I can adjust the default
         public ulong EventBodyLimitBytes { get; set; } = 256 * 1024;
         public ulong RawPayloadLimitBytes { get; set; } = 10 * 1024 * 1024;
-
+        
         [JsonProperty("apiKey")]
         public string EncodedApiKey { get; set; }
 

--- a/src/Seq.Forwarder/Shipper/HttpLogShipper.cs
+++ b/src/Seq.Forwarder/Shipper/HttpLogShipper.cs
@@ -64,7 +64,7 @@ namespace Seq.Forwarder.Shipper
             if (!baseUri.EndsWith("/"))
                 baseUri += "/";
 
-            _httpClient = new HttpClient { BaseAddress = new Uri(baseUri) };
+            _httpClient = new HttpClient { BaseAddress = new Uri(baseUri), Timeout = TimeSpan.FromMilliseconds(_outputConfig.SocketLifetime - 1000) };
             _timer = new Timer(s => OnTick());
         }
 
@@ -103,7 +103,7 @@ namespace Seq.Forwarder.Shipper
             if (_timer.Dispose(wh))
                 wh.WaitOne();
         }
-        
+
         public override void Dispose()
         {
             Stop();
@@ -216,7 +216,7 @@ namespace Seq.Forwarder.Shipper
             var content = new StreamWriter(raw, Encoding.UTF8);
             content.Write("{\"Events\":[");
             content.Flush();
-            var contentRemainingBytes = (int) _outputConfig.RawPayloadLimitBytes - 13; // Includes closing delims
+            var contentRemainingBytes = (int)_outputConfig.RawPayloadLimitBytes - 13; // Includes closing delims
 
             var delimStart = "";
             foreach (var logBufferEntry in entries)


### PR DESCRIPTION
The default length is what we use for timeout, but not sure if there is a sweetspot for how often the log shipper runs.  The other piece of this is using the httpclient as a singleton which looks like a huge change based on how this is architected.  I'll start with this and we can discuss