### PR TITLE
Reuse a single HttpClient instance for all requests

### DIFF
--- a/src/Seq.Forwarder/Importer/HttpImporter.cs
+++ b/src/Seq.Forwarder/Importer/HttpImporter.cs
@@ -36,13 +36,12 @@ namespace Seq.Forwarder.Importer
 
         public HttpImporter(BufferedLogReader logReader, SeqImportConfig importConfig)
         {
-            if (logReader == null) throw new ArgumentNullException(nameof(logReader));
             if (importConfig == null) throw new ArgumentNullException(nameof(importConfig));
 
             if (string.IsNullOrWhiteSpace(importConfig.ServerUrl))
                 throw new ArgumentException("The destination Seq server URL must be provided.");
 
-            _logReader = logReader;
+            _logReader = logReader ?? throw new ArgumentNullException(nameof(logReader));
             _importConfig = importConfig;
 
             var baseUri = importConfig.ServerUrl;

--- a/src/Seq.Forwarder/Multiplexing/HttpLogShipperFactory.cs
+++ b/src/Seq.Forwarder/Multiplexing/HttpLogShipperFactory.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Net.Http;
 using Seq.Forwarder.Config;
 using Seq.Forwarder.Shipper;
 using Seq.Forwarder.Storage;
@@ -21,18 +22,20 @@ namespace Seq.Forwarder.Multiplexing
 {
     class HttpLogShipperFactory : ILogShipperFactory
     {
+        readonly HttpClient _outputHttpClient;
         readonly ServerResponseProxy _serverResponseProxy;
         readonly SeqForwarderOutputConfig _outputConfig;
 
-        public HttpLogShipperFactory(ServerResponseProxy serverResponseProxy, SeqForwarderOutputConfig outputConfig)
+        public HttpLogShipperFactory(ServerResponseProxy serverResponseProxy, SeqForwarderOutputConfig outputConfig, HttpClient outputHttpClient)
         {
+            _outputHttpClient = outputHttpClient;
             _serverResponseProxy = serverResponseProxy ?? throw new ArgumentNullException(nameof(serverResponseProxy));
             _outputConfig = outputConfig ?? throw new ArgumentNullException(nameof(outputConfig));
         }
 
         public LogShipper Create(LogBuffer logBuffer, string apiKey)
         {
-            return new HttpLogShipper(logBuffer, apiKey, _outputConfig, _serverResponseProxy);
+            return new HttpLogShipper(logBuffer, apiKey, _outputConfig, _serverResponseProxy, _outputHttpClient);
         }
     }
 }

--- a/src/Seq.Forwarder/Properties/launchSettings.json
+++ b/src/Seq.Forwarder/Properties/launchSettings.json
@@ -1,8 +1,7 @@
 {
   "profiles": {
     "Seq.Forwarder": {
-      "commandName": "Project",
-      "commandLineArgs": "run"
+      "commandName": "Project"
     }
   }
 }

--- a/src/Seq.Forwarder/Seq.Forwarder.csproj
+++ b/src/Seq.Forwarder/Seq.Forwarder.csproj
@@ -42,15 +42,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="autofac" Version="4.6.1" />
-    <PackageReference Include="lightningdb" Version="0.9.9" />
+    <PackageReference Include="autofac" Version="4.6.2" />
+    <PackageReference Include="lightningdb" Version="0.10.0" />
     <PackageReference Include="nancy" Version="1.4.4" />
     <PackageReference Include="nancy.bootstrappers.autofac" Version="1.4.1" />
     <PackageReference Include="nancy.hosting.self" Version="1.4.1" />
     <PackageReference Include="newtonsoft.json" Version="10.0.3" />
-    <PackageReference Include="serilog" Version="2.5.0" />
+    <PackageReference Include="serilog" Version="2.6.0" />
     <PackageReference Include="serilog.formatting.compact" Version="1.0.0" />
-    <PackageReference Include="serilog.sinks.console" Version="3.0.1" />
+    <PackageReference Include="serilog.sinks.console" Version="3.1.1" />
     <PackageReference Include="serilog.sinks.rollingfile" Version="3.3.0" />
   </ItemGroup>
 

--- a/src/Seq.Forwarder/SeqForwarderModule.cs
+++ b/src/Seq.Forwarder/SeqForwarderModule.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016-2017 Datalust Pty Ltd
+﻿// Copyright 2016-2018 Datalust Pty Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Net.Http;
 using Autofac;
 using Nancy;
 using Seq.Forwarder.Config;
@@ -57,6 +58,18 @@ namespace Seq.Forwarder
             builder.RegisterInstance(_config.Storage);
             builder.RegisterInstance(_config.Output);
             builder.RegisterType<ServerResponseProxy>().SingleInstance();
+
+            builder.Register(c =>
+            {
+                var baseUri = c.Resolve<SeqForwarderOutputConfig>().ServerUrl;
+                if (string.IsNullOrWhiteSpace(baseUri))
+                    throw new ArgumentException("The destination Seq server URL must be configured in SeqForwarder.json.");
+
+                if (!baseUri.EndsWith("/"))
+                    baseUri += "/";
+
+                return new HttpClient { BaseAddress = new Uri(baseUri) };
+            }).SingleInstance();
         }
     }
 }

--- a/test/Seq.Forwarder.Tests/Seq.Forwarder.Tests.csproj
+++ b/test/Seq.Forwarder.Tests/Seq.Forwarder.Tests.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Investigating #37 - it seems we can re-use a single `HttpClient` for all requests, so no reason to avoid doing this.

PR moves `HttpClient` to the container to become a singleton.

Updates some dependencies, since we'll be testing the resulting `-dev` package.