### PR TITLE
Enable TLS 1.2 support

### DIFF
--- a/src/Seq.Forwarder/ServiceProcess/SeqForwarderWindowsService.cs
+++ b/src/Seq.Forwarder/ServiceProcess/SeqForwarderWindowsService.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Net;
 using System.ServiceProcess;
 
 namespace Seq.Forwarder.ServiceProcess
@@ -26,6 +27,10 @@ namespace Seq.Forwarder.ServiceProcess
 
         public SeqForwarderWindowsService(ServerService serverService, IDisposable disposeOnStop)
         {
+            // Enable TLS 1.2 Support.
+            // .NET Framework 4.5.2 does not have it enabled by default
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
+
             _serverService = serverService;
             _disposeOnStop = disposeOnStop;
 


### PR DESCRIPTION
Enable TLS 1.2 support, which is not enabled by default in .NET Framework 4.5.2. See issue #46 