### PR TITLE
Optionally use Environment Variables for Config

### DIFF
--- a/src/Seq.Forwarder/Cli/Commands/ConfigCommand.cs
+++ b/src/Seq.Forwarder/Cli/Commands/ConfigCommand.cs
@@ -44,7 +44,7 @@ namespace Seq.Forwarder.Cli.Commands
         {
             try
             {
-                var config = SeqForwarderConfig.ReadOrInit(_storagePath.ConfigFilePath);
+                var config = SeqForwarderConfig.ReadOrInit(_storagePath.ConfigFilePath, false);
 
                 if (_key != null)
                 {
@@ -147,7 +147,7 @@ namespace Seq.Forwarder.Cli.Commands
 
                 foreach (var second in v.GetType().GetTypeInfo().DeclaredProperties
                     .Where(p => p.GetMethod != null && p.GetMethod.IsPublic && p.SetMethod != null &&
-                                p.SetMethod.IsPublic && !p.GetMethod.IsStatic && !p.Name.Equals(nameof(SeqForwarderOutputConfig.ApiKey)))
+                                p.SetMethod.IsPublic && !p.GetMethod.IsStatic && p.Name != nameof(SeqForwarderOutputConfig.ApiKey))
                     .OrderBy(p => p.Name))
                 {
                     var name = step1 + Camelize(second.Name);

--- a/src/Seq.Forwarder/Cli/Commands/ConfigCommand.cs
+++ b/src/Seq.Forwarder/Cli/Commands/ConfigCommand.cs
@@ -147,7 +147,7 @@ namespace Seq.Forwarder.Cli.Commands
 
                 foreach (var second in v.GetType().GetTypeInfo().DeclaredProperties
                     .Where(p => p.GetMethod != null && p.GetMethod.IsPublic && p.SetMethod != null &&
-                                p.SetMethod.IsPublic && !p.GetMethod.IsStatic && !p.Name.StartsWith("Encoded"))
+                                p.SetMethod.IsPublic && !p.GetMethod.IsStatic && !p.Name.Equals(nameof(SeqForwarderOutputConfig.ApiKey)))
                     .OrderBy(p => p.Name))
                 {
                     var name = step1 + Camelize(second.Name);

--- a/src/Seq.Forwarder/Config/SeqForwarderConfig.cs
+++ b/src/Seq.Forwarder/Config/SeqForwarderConfig.cs
@@ -14,6 +14,9 @@
 
 using System;
 using System.IO;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Extensions.Configuration;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
@@ -45,8 +48,28 @@ namespace Seq.Forwarder.Config
             }
 
             var content = File.ReadAllText(filename);
-            return JsonConvert.DeserializeObject<SeqForwarderConfig>(content, SerializerSettings) ??
-                throw new ArgumentException("Configuration content is null.");
+            var seqForwarderConfig = JsonConvert.DeserializeObject<SeqForwarderConfig>(content, SerializerSettings);
+
+            // Any Environment Variables overwrite those in the Config File
+            var envVarConfig = new ConfigurationBuilder().AddEnvironmentVariables("FORWARDER_").Build();
+            foreach (var sectionProperty in typeof(SeqForwarderConfig).GetTypeInfo().DeclaredProperties
+                .Where(p => p.GetMethod != null && p.GetMethod.IsPublic && !p.GetMethod.IsStatic))
+            {
+                foreach (var subGroupProperty in sectionProperty.PropertyType.GetTypeInfo().DeclaredProperties
+                    .Where(p => p.GetMethod != null && p.GetMethod.IsPublic && p.SetMethod != null && p.SetMethod.IsPublic && !p.GetMethod.IsStatic))
+                {
+                    var envVarName = sectionProperty.Name.ToUpper() + "_" + subGroupProperty.Name.ToUpper();
+                    var envVarVal = envVarConfig.GetValue(subGroupProperty.PropertyType, envVarName);
+                    if (envVarVal != null)
+                    {
+                        seqForwarderConfig ??= new SeqForwarderConfig();
+                        subGroupProperty.SetValue(sectionProperty.GetValue(seqForwarderConfig), envVarVal);
+                    }
+                }
+            }
+
+            return seqForwarderConfig ?? 
+                   throw new ArgumentException("Configuration content is null.");
         }
 
         public static void Write(string filename, SeqForwarderConfig data)

--- a/src/Seq.Forwarder/Config/SeqForwarderConfig.cs
+++ b/src/Seq.Forwarder/Config/SeqForwarderConfig.cs
@@ -48,7 +48,8 @@ namespace Seq.Forwarder.Config
             }
 
             var content = File.ReadAllText(filename);
-            var seqForwarderConfig = JsonConvert.DeserializeObject<SeqForwarderConfig>(content, SerializerSettings);
+            var combinedConfig = JsonConvert.DeserializeObject<SeqForwarderConfig>(content, SerializerSettings)
+                ?? throw new ArgumentException("Configuration content is null.");
 
             // Any Environment Variables overwrite those in the Config File
             var envVarConfig = new ConfigurationBuilder().AddEnvironmentVariables("FORWARDER_").Build();
@@ -62,14 +63,12 @@ namespace Seq.Forwarder.Config
                     var envVarVal = envVarConfig.GetValue(subGroupProperty.PropertyType, envVarName);
                     if (envVarVal != null)
                     {
-                        seqForwarderConfig ??= new SeqForwarderConfig();
-                        subGroupProperty.SetValue(sectionProperty.GetValue(seqForwarderConfig), envVarVal);
+                        subGroupProperty.SetValue(sectionProperty.GetValue(combinedConfig), envVarVal);
                     }
                 }
             }
 
-            return seqForwarderConfig ?? 
-                   throw new ArgumentException("Configuration content is null.");
+            return combinedConfig;
         }
 
         public static void Write(string filename, SeqForwarderConfig data)

--- a/src/Seq.Forwarder/Config/SeqForwarderOutputConfig.cs
+++ b/src/Seq.Forwarder/Config/SeqForwarderOutputConfig.cs
@@ -27,29 +27,28 @@ namespace Seq.Forwarder.Config
 
         const string ProtectedDataPrefix = "pd.";
 
-        [JsonProperty("apiKey")]
-        public string? EncodedApiKey { get; set; }
+        public string? ApiKey { get; set; }
 
         public string? GetApiKey(IStringDataProtector dataProtector)
         {
-            if (string.IsNullOrWhiteSpace(EncodedApiKey))
+            if (string.IsNullOrWhiteSpace(ApiKey))
                 return null;
 
-            if (!EncodedApiKey.StartsWith(ProtectedDataPrefix))
-                return EncodedApiKey;
+            if (!ApiKey.StartsWith(ProtectedDataPrefix))
+                return ApiKey;
 
-            return dataProtector.Unprotect(EncodedApiKey.Substring(ProtectedDataPrefix.Length));
+            return dataProtector.Unprotect(ApiKey.Substring(ProtectedDataPrefix.Length));
         }
         
         public void SetApiKey(string? apiKey, IStringDataProtector dataProtector)
         {
             if (string.IsNullOrWhiteSpace(apiKey))
             {
-                EncodedApiKey = null;
+                ApiKey = null;
                 return;
             }
 
-            EncodedApiKey = $"{ProtectedDataPrefix}{dataProtector.Protect(apiKey)}";
+            ApiKey = $"{ProtectedDataPrefix}{dataProtector.Protect(apiKey)}";
         }
     }
 }


### PR DESCRIPTION
Hi Nick

I've had a go at implementing Environment Variables for the config. Hopefully it's what you had in mind but you may have a better strategy. Here's some explanations for the pull request;

Example Environment Variable names:
`FORWARDER_OUTPUT_RAWPAYLOADLIMITBYTES`
`FORWARDER_DIAGNOSTICS_INTERNALLOGGINGLEVEL`

Its using the `Microsoft.Extensions.Configuration.ConfigurationBuilder` to load the Environment Variables and the `GetValue()` method to get each variable the right type.

Its renamed property `EncodedApiKey` to `ApiKey` so that the environment variable `FORWARDER_OUTPUT_APIKEY` would match. (Also updated the check that excludes it in `ConfigCommand`).

With these changes, the Config command lists the config file with environment variables overwritten, and writes update the config file with any changes as well as any overwritten environment variables. Not sure if that is the expectation.

If you have ideas for improvement I'm all ears. If you think a different way would be better that's ok too.

Addresses #55 