### PR TITLE
Update to .NET 8 and current dependency versions

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ artifacts:
   - path: artifacts/seqfwd-*.tar.gz
 
 build_script:
-  - ps: ./Build.ps1 -shortver "$($env:APPVEYOR_BUILD_VERSION)"
+  - pwsh: ./Build.ps1 -shortver "$($env:APPVEYOR_BUILD_VERSION)"
 
 deploy:
   - provider: GitHub

--- a/seq-forwarder.sln
+++ b/seq-forwarder.sln
@@ -26,18 +26,18 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "data", "data", "{CAE68175-E
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|x64 = Debug|x64
-		Release|x64 = Release|x64
+		Release|Any CPU = Release|Any CPU
+		Debug|Any CPU = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{206FCC39-00A9-4C3D-998F-E0D3538E4786}.Debug|x64.ActiveCfg = Debug|x64
-		{206FCC39-00A9-4C3D-998F-E0D3538E4786}.Debug|x64.Build.0 = Debug|x64
-		{206FCC39-00A9-4C3D-998F-E0D3538E4786}.Release|x64.ActiveCfg = Release|x64
-		{206FCC39-00A9-4C3D-998F-E0D3538E4786}.Release|x64.Build.0 = Release|x64
-		{88984363-1BD7-4E60-99B9-7D07666990B8}.Debug|x64.ActiveCfg = Debug|x64
-		{88984363-1BD7-4E60-99B9-7D07666990B8}.Debug|x64.Build.0 = Debug|x64
-		{88984363-1BD7-4E60-99B9-7D07666990B8}.Release|x64.ActiveCfg = Release|x64
-		{88984363-1BD7-4E60-99B9-7D07666990B8}.Release|x64.Build.0 = Release|x64
+		{206FCC39-00A9-4C3D-998F-E0D3538E4786}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{206FCC39-00A9-4C3D-998F-E0D3538E4786}.Release|Any CPU.Build.0 = Release|Any CPU
+		{206FCC39-00A9-4C3D-998F-E0D3538E4786}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{206FCC39-00A9-4C3D-998F-E0D3538E4786}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{88984363-1BD7-4E60-99B9-7D07666990B8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{88984363-1BD7-4E60-99B9-7D07666990B8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{88984363-1BD7-4E60-99B9-7D07666990B8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{88984363-1BD7-4E60-99B9-7D07666990B8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/seq-forwarder.sln.DotSettings
+++ b/seq-forwarder.sln.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IO/@EntryIndexedValue">IO</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IP/@EntryIndexedValue">IP</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=apikey/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=binpath/@EntryIndexedValue">True</s:Boolean>

--- a/src/Seq.Forwarder/Cli/Commands/RunCommand.cs
+++ b/src/Seq.Forwarder/Cli/Commands/RunCommand.cs
@@ -41,7 +41,7 @@ namespace Seq.Forwarder.Cli.Commands
 
         public RunCommand()
         {
-            Options.Add("nologo", v => _noLogo = true);
+            Options.Add("nologo", _ => _noLogo = true);
             _storagePath = Enable<StoragePathFeature>();
             _listenUri = Enable<ListenUriFeature>();
         }
@@ -149,8 +149,7 @@ namespace Seq.Forwarder.Cli.Commands
             if (!string.IsNullOrWhiteSpace(internalLogServerUri))
                 loggerConfiguration.WriteTo.Seq(
                     internalLogServerUri,
-                    apiKey: internalLogServerApiKey,
-                    compact: true);
+                    apiKey: internalLogServerApiKey);
 
             return loggerConfiguration.CreateLogger();
         }

--- a/src/Seq.Forwarder/Cli/Options.cs
+++ b/src/Seq.Forwarder/Cli/Options.cs
@@ -669,21 +669,8 @@ namespace Seq.Forwarder.Cli
 			this.option = optionName;
 		}
 
-		protected OptionException (SerializationInfo info, StreamingContext context)
-			: base (info, context)
-		{
-			this.option = info.GetString ("OptionName");
-		}
-
 		public string OptionName {
 			get {return this.option;}
-		}
-
-		[SecurityPermission (SecurityAction.LinkDemand, SerializationFormatter = true)]
-		public override void GetObjectData (SerializationInfo info, StreamingContext context)
-		{
-			base.GetObjectData (info, context);
-			info.AddValue ("OptionName", option);
 		}
 	}
 

--- a/src/Seq.Forwarder/Config/SeqForwarderConfig.cs
+++ b/src/Seq.Forwarder/Config/SeqForwarderConfig.cs
@@ -81,7 +81,7 @@ namespace Seq.Forwarder.Config
 
             var dir = Path.GetDirectoryName(filename);
             if (!Directory.Exists(dir))
-                Directory.CreateDirectory(dir);
+                Directory.CreateDirectory(dir!);
             
             var content = JsonConvert.SerializeObject(data, Formatting.Indented, SerializerSettings);
             File.WriteAllText(filename, content);

--- a/src/Seq.Forwarder/Schema/EventSchema.cs
+++ b/src/Seq.Forwarder/Schema/EventSchema.cs
@@ -123,7 +123,7 @@ namespace Seq.Forwarder.Schema
                 {
                     // ReSharper disable once PossibleMultipleEnumeration
                     var renderingsByProperty = withFormat
-                        .Zip(renderingsArray, (p, j) => new { p.PropertyName, p.Format, Rendering = j.Value<string>() })
+                        .Zip(renderingsArray, (p, j) => new { p.PropertyName, Format = p.Format!, Rendering = j.Value<string>() })
                         .GroupBy(p => p.PropertyName)
                         .ToDictionary(g => g.Key, g => g.ToDictionaryDistinct(p => p.Format, p => p.Rendering));
 

--- a/src/Seq.Forwarder/Seq.Forwarder.csproj
+++ b/src/Seq.Forwarder/Seq.Forwarder.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
@@ -13,7 +13,7 @@
     <Description>Seq HTTP Log Forwarder</Description>
     <Copyright>Copyright © Datalust Pty Ltd and Contributors</Copyright>
     <AssemblyName>seqfwd</AssemblyName>
-    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
     <Nullable>Enable</Nullable>
   </PropertyGroup>
 
@@ -21,29 +21,29 @@
     <IsWindows>true</IsWindows>
     <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(SeqForwarderRid)' == 'linux-x64' Or ('$(SeqForwarderRid)' == '' And '$([MSBuild]::IsOsPlatform(`LINUX`))' == 'true')">
+  <PropertyGroup Condition=" '$(SeqForwarderRid)' == 'linux-x64' Or '$(SeqForwarderRid)' == 'linux-arm64' Or ('$(SeqForwarderRid)' == '' And '$([MSBuild]::IsOsPlatform(`LINUX`))' == 'true')">
     <IsLinux>true</IsLinux>
     <IsUnix>true</IsUnix>
     <DefineConstants>$(DefineConstants);LINUX;UNIX</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(SeqForwarderRid)' == 'osx-x64'  Or ('$(SeqForwarderRid)' == '' And '$([MSBuild]::IsOsPlatform(`OSX`))' == 'true')">
+  <PropertyGroup Condition=" '$(SeqForwarderRid)' == 'osx-x64' Or '$(SeqForwarderRid)' == 'osx-arm64'  Or ('$(SeqForwarderRid)' == '' And '$([MSBuild]::IsOsPlatform(`OSX`))' == 'true')">
     <IsMacOS>true</IsMacOS>
     <IsUnix>true</IsUnix>
     <DefineConstants>$(DefineConstants);MACOS;UNIX</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="autofac" Version="5.2.0" />
-    <PackageReference Include="autofac.extensions.dependencyinjection" Version="6.0.0" />
+    <PackageReference Include="autofac" Version="8.0.0" />
+    <PackageReference Include="autofac.extensions.dependencyinjection" Version="9.0.0" />
     <PackageReference Include="lightningdb" Version="0.10.0" />
-    <PackageReference Include="newtonsoft.json" Version="13.0.1" />
-    <PackageReference Include="serilog" Version="2.9.0" />
-    <PackageReference Include="serilog.aspnetcore" Version="3.4.0" />
-    <PackageReference Include="serilog.formatting.compact" Version="1.1.0" />
-    <PackageReference Include="serilog.sinks.console" Version="3.1.1" />
-    <PackageReference Include="serilog.sinks.file" Version="4.1.0" />
-    <PackageReference Include="serilog.sinks.seq" Version="4.0.0" />
-    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.7.0" />
+    <PackageReference Include="newtonsoft.json" Version="13.0.3" />
+    <PackageReference Include="serilog" Version="3.1.1" />
+    <PackageReference Include="serilog.aspnetcore" Version="8.0.1" />
+    <PackageReference Include="serilog.formatting.compact" Version="2.0.0" />
+    <PackageReference Include="serilog.sinks.console" Version="5.0.1" />
+    <PackageReference Include="serilog.sinks.file" Version="5.0.0" />
+    <PackageReference Include="serilog.sinks.seq" Version="6.0.0" />
+    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
   </ItemGroup>
   
   <ItemGroup Condition=" '$(IsWindows)' == 'true' ">

--- a/src/Seq.Forwarder/Util/CaptiveProcess.cs
+++ b/src/Seq.Forwarder/Util/CaptiveProcess.cs
@@ -48,12 +48,12 @@ namespace Seq.Forwarder.Util
             if (!string.IsNullOrEmpty(workingDirectory))
                 startInfo.WorkingDirectory = workingDirectory;
 
-            using var process = Process.Start(startInfo);
+            using var process = Process.Start(startInfo)!;
             using var outputComplete = new ManualResetEvent(false);
             using var errorComplete = new ManualResetEvent(false);
             // ReSharper disable AccessToDisposedClosure
 
-            process.OutputDataReceived += (o, e) =>
+            process.OutputDataReceived += (_, e) =>
             {
                 if (e.Data == null)
                     outputComplete.Set(); 
@@ -62,7 +62,7 @@ namespace Seq.Forwarder.Util
             };
             process.BeginOutputReadLine();
 
-            process.ErrorDataReceived += (o, e) =>
+            process.ErrorDataReceived += (_, e) =>
             {
                 if (e.Data == null)
                     errorComplete.Set();

--- a/src/Seq.Forwarder/Web/Api/IngestionController.cs
+++ b/src/Seq.Forwarder/Web/Api/IngestionController.cs
@@ -51,7 +51,7 @@ namespace Seq.Forwarder.Web.Api
             _serverResponseProxy = serverResponseProxy;
         }
 
-        IPAddress ClientHostIP => Request.HttpContext.Connection.RemoteIpAddress;
+        IPAddress ClientHostIP => Request.HttpContext.Connection.RemoteIpAddress!;
 
         [HttpGet, Route("api/events/describe")]
         public IActionResult Resources()
@@ -67,7 +67,7 @@ namespace Seq.Forwarder.Web.Api
             if (clef)
                 return await IngestCompactFormat();
 
-            var contentType = (string) Request.Headers[HeaderNames.ContentType];
+            var contentType = (string?) Request.Headers[HeaderNames.ContentType];
             if (contentType != null && contentType.StartsWith(ClefMediaType))
                 return await IngestCompactFormat();
 
@@ -77,7 +77,7 @@ namespace Seq.Forwarder.Web.Api
         IActionResult IngestRawFormat()
         {
             // The compact format ingestion path works with async IO.
-            HttpContext.Features.Get<IHttpBodyControlFeature>().AllowSynchronousIO = true;
+            HttpContext.Features.Get<IHttpBodyControlFeature>()!.AllowSynchronousIO = true;
             
             JObject posted;
             try
@@ -91,8 +91,7 @@ namespace Seq.Forwarder.Web.Api
                 throw new RequestProcessingException("Invalid raw event JSON, body could not be parsed.");
             }
 
-            if (posted == null ||
-                !(posted.TryGetValue("events", StringComparison.Ordinal, out var eventsToken) ||
+            if (!(posted.TryGetValue("events", StringComparison.Ordinal, out var eventsToken) ||
                   posted.TryGetValue("Events", StringComparison.Ordinal, out eventsToken)))
             {
                 IngestionLog.ForClient(ClientHostIP).Debug("Rejecting payload due to invalid JSON structure");
@@ -232,10 +231,10 @@ namespace Seq.Forwarder.Web.Api
             if (parameter.Count != 1)
                 return false;
 
-            var value = (string) parameter;
+            var value = (string?) parameter;
 
             if (value == "" && (
-                Request.QueryString.Value.Contains($"&{queryParameterName}=") ||
+                Request.QueryString.Value!.Contains($"&{queryParameterName}=") ||
                 Request.QueryString.Value.Contains($"?{queryParameterName}=")))
             {
                 return false;

--- a/test/Seq.Forwarder.Tests/Seq.Forwarder.Tests.csproj
+++ b/test/Seq.Forwarder.Tests/Seq.Forwarder.Tests.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <PlatformTarget>x64</PlatformTarget>
-    <Prefer32Bit>false</Prefer32Bit>
-    <Platforms>AnyCPU;x64</Platforms>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>Enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR also adds ARM targets for macOS and Linux.

The `lightningdb` dependency remains a TODO; IIRC we hit some compatibility issues earlier, trying to open older ldmdb storage files with the more recent lightningdb package versions. Needs some investigation.

Closes #69
